### PR TITLE
sbmlRelational: re-use the same type of "false" that failed the condition

### DIFF
--- a/src/interpret.jl
+++ b/src/interpret.jl
@@ -14,7 +14,7 @@ end
 sbmlNeq(a, b) = !isequal(a, b)
 function sbmlRelational(op)
     _iter(x,y) = op(x,y)
-    _iter(x,y,args...) = IfElse.ifelse(op(x,y), _iter(y,args...), Num(false))
+    _iter(x,y,args...) = IfElse.ifelse(op(x,y), _iter(y,args...), op(x,y))
     _iter
 end
 


### PR DESCRIPTION
also format.